### PR TITLE
add option to set a description to the generated help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Once everything is set up, a paternoster script can be used like this:
 $ create-user --help
 usage: create-user [-h] -u USERNAME [-v]
 
+Create a user.
+
 required arguments:
   -u USERNAME, --username USERNAME
                         name of the user to create
@@ -36,7 +38,7 @@ which contains the configuration for parameter parsing and other features.
 
 - hosts: paternoster
   vars:
-    description: add new user
+    description: Create a user.
     parameters:
       - name: username
         short: u

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ which contains the configuration for parameter parsing and other features.
 
 - hosts: paternoster
   vars:
-    help_msg: add new user
+    description: add new user
     parameters:
       - name: username
         short: u

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ which contains the configuration for parameter parsing and other features.
 
 - hosts: paternoster
   vars:
+    help_msg: add new user
     parameters:
       - name: username
         short: u

--- a/doc/script_development.md
+++ b/doc/script_development.md
@@ -27,7 +27,8 @@ Inside `vars` the following values can be set:
 * `parameters`: command line parameters to parse, check and pass on to ansible
 * `become_user`: use `sudo` to execute the playbook as the given user (e.g. `root`)
 * `check_user`: check that the user running the script is the one given here
-* `success_msg`: print this message once the script as exited successfully
+* `success_msg`: print this message once the script has exited successfully
+* `help_msg`: a short description of the script's purpose (for `--help` output)
 
 ## Parameters
 

--- a/doc/script_development.md
+++ b/doc/script_development.md
@@ -28,7 +28,7 @@ Inside `vars` the following values can be set:
 * `become_user`: use `sudo` to execute the playbook as the given user (e.g. `root`)
 * `check_user`: check that the user running the script is the one given here
 * `success_msg`: print this message once the script has exited successfully
-* `help_msg`: a short description of the script's purpose (for `--help` output)
+* `description`: a short description of the script's purpose (for `--help` output)
 
 ## Parameters
 

--- a/paternoster/paternoster.py
+++ b/paternoster/paternoster.py
@@ -19,12 +19,14 @@ class Paternoster:
                  parameters,
                  become_user=None, check_user=None,
                  success_msg=None,
+                 help_msg=None,
                  runner_class=AnsibleRunner,
                  ):
         self._parameters = parameters
         self._become_user = become_user
         self._check_user = check_user
         self._success_msg = success_msg
+        self._help_msg = help_msg
         self._sudo_user = None
         self._runner = runner_class(**runner_parameters)
 
@@ -68,7 +70,10 @@ class Paternoster:
             argParams['type'] = param_type
 
     def _build_argparser(self):
-        parser = argparse.ArgumentParser(add_help=False)
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            description=self._help_msg,
+        )
         requiredArgs = parser.add_argument_group('required arguments')
         optionalArgs = parser.add_argument_group('optional arguments')
 

--- a/paternoster/paternoster.py
+++ b/paternoster/paternoster.py
@@ -19,14 +19,14 @@ class Paternoster:
                  parameters,
                  become_user=None, check_user=None,
                  success_msg=None,
-                 help_msg=None,
+                 description=None,
                  runner_class=AnsibleRunner,
                  ):
         self._parameters = parameters
         self._become_user = become_user
         self._check_user = check_user
         self._success_msg = success_msg
-        self._help_msg = help_msg
+        self._description = description
         self._sudo_user = None
         self._runner = runner_class(**runner_parameters)
 
@@ -72,7 +72,7 @@ class Paternoster:
     def _build_argparser(self):
         parser = argparse.ArgumentParser(
             add_help=False,
-            description=self._help_msg,
+            description=self._description,
         )
         requiredArgs = parser.add_argument_group('required arguments')
         optionalArgs = parser.add_argument_group('optional arguments')

--- a/paternoster/test/test_parameters.py
+++ b/paternoster/test/test_parameters.py
@@ -186,17 +186,17 @@ def test_success_msg(success_msg, expected, capsys):
     assert out == expected
 
 
-@pytest.mark.parametrize("help_msg,expected", [
+@pytest.mark.parametrize("description,expected", [
     ('Do things with stuff', 'Do things with stuff\n\n'),
     ('', ''),
     (None, ''),
 ])
-def test_help_msg(help_msg, expected, capsys):
+def test_description(description, expected, capsys):
     s = Paternoster(
         runner_parameters={},
         parameters=[],
         runner_class=MockRunner,
-        help_msg=help_msg,
+        description=description,
     )
     with pytest.raises(SystemExit):
         s.parse_args(['--help'])

--- a/paternoster/test/test_parameters.py
+++ b/paternoster/test/test_parameters.py
@@ -184,3 +184,23 @@ def test_success_msg(success_msg, expected, capsys):
 
     out, err = capsys.readouterr()
     assert out == expected
+
+
+@pytest.mark.parametrize("help_msg,expected", [
+    ('Do things with stuff', 'Do things with stuff\n\n'),
+    ('', ''),
+    (None, ''),
+])
+def test_help_msg(help_msg, expected, capsys):
+    s = Paternoster(
+        runner_parameters={},
+        parameters=[],
+        runner_class=MockRunner,
+        help_msg=help_msg,
+    )
+    with pytest.raises(SystemExit):
+        s.parse_args(['--help'])
+
+    out, err = capsys.readouterr()
+    exp_help_text = 'usage: py.test [-h] [-v]\n\n{expected}optional arguments:'
+    assert out.startswith(exp_help_text.format(expected=expected))


### PR DESCRIPTION
If `description` is set in _vars_, it is added to the generated help output, as an introductory description.