### PR TITLE
made the `parameters` argument optional

### DIFF
--- a/paternoster/paternoster.py
+++ b/paternoster/paternoster.py
@@ -16,13 +16,16 @@ import paternoster.types
 class Paternoster:
     def __init__(self,
                  runner_parameters,
-                 parameters,
+                 parameters=None,
                  become_user=None, check_user=None,
                  success_msg=None,
                  description=None,
                  runner_class=AnsibleRunner,
                  ):
-        self._parameters = parameters
+        if parameters is None:
+            self._parameters = []
+        else:
+            self._parameters = parameters
         self._become_user = become_user
         self._check_user = check_user
         self._success_msg = success_msg

--- a/paternoster/test/test_parameters.py
+++ b/paternoster/test/test_parameters.py
@@ -204,3 +204,20 @@ def test_description(description, expected, capsys):
     out, err = capsys.readouterr()
     exp_help_text = 'usage: py.test [-h] [-v]\n\n{expected}optional arguments:'
     assert out.startswith(exp_help_text.format(expected=expected))
+
+
+def test_arg_parameters_none():
+    s = Paternoster(
+        runner_parameters={},
+        parameters=None,
+        runner_class=MockRunner,
+    )
+    assert s._parameters == []
+
+
+def test_arg_parameters_missing():
+    s = Paternoster(
+        runner_parameters={},
+        runner_class=MockRunner,
+    )
+    assert s._parameters == []


### PR DESCRIPTION
I made the *parameters* argument optional. So one can skip the `parameters: []` declaration in scripts. But it's still okay to use it to be explicit.