### PR TITLE
Fix DNS root handling for FQDNs

### DIFF
--- a/paternoster/test/test_types.py
+++ b/paternoster/test/test_types.py
@@ -26,6 +26,9 @@ import pytest
     ("a" * 65 + ".com", False, False),
     (("a" * 40 + '.') * 8 + "com", False, False),
     ('', False, False),
+    ('example.com.', False, True)
+    ('*.example.com.', True, True)
+    ('.', False, False)
 ])
 def test_type_domain(value, wildcard, valid):
     from ..types import domain

--- a/paternoster/types/__init__.py
+++ b/paternoster/types/__init__.py
@@ -15,6 +15,9 @@ class domain:
 
         if self._wildcard and val.startswith('*.'):
             val = val[2:]
+            
+        if val.endswith('.'):
+            val = val[:-1]
 
         extracted = tldextract.TLDExtract(suffix_list_urls=[])(val)
 

--- a/paternoster/types/__init__.py
+++ b/paternoster/types/__init__.py
@@ -18,6 +18,7 @@ class domain:
 
         if val.endswith('.'):
             val = val[:-1]
+            domain = domain[:-1]
 
         extracted = tldextract.TLDExtract(suffix_list_urls=[])(val)
 

--- a/paternoster/types/__init__.py
+++ b/paternoster/types/__init__.py
@@ -13,12 +13,11 @@ class domain:
         val = val.encode('idna').decode('ascii')
         domain = val
 
+        if val.endswith('.'):
+            domain = val = val[:-1]
+
         if self._wildcard and val.startswith('*.'):
             val = val[2:]
-
-        if val.endswith('.'):
-            val = val[:-1]
-            domain = domain[:-1]
 
         extracted = tldextract.TLDExtract(suffix_list_urls=[])(val)
 

--- a/paternoster/types/__init__.py
+++ b/paternoster/types/__init__.py
@@ -15,7 +15,7 @@ class domain:
 
         if self._wildcard and val.startswith('*.'):
             val = val[2:]
-            
+
         if val.endswith('.'):
             val = val[:-1]
 


### PR DESCRIPTION
FQDNs end with a `.` that separates the TLD label from the DNS root label (empty label).
For example `example.com`'s FQDN is `example.com.`.
The [Uberspace Documentation](https://manual.uberspace.de/en/mail-domains.html#setup) states that the `uberspace` script expects a FQDN which is how I noticed the bug.
`DOMAIN_REGEX` doesn't match FQDNs which is why the `uberspace` script fails when given a FQDN.
See [Wikipedia](https://en.wikipedia.org/wiki/Fully_qualified_domain_name#Syntax).