### PR TITLE
:art: detect email address like input

### DIFF
--- a/paternoster/test/test_types.py
+++ b/paternoster/test/test_types.py
@@ -43,6 +43,14 @@ def test_type_domain(value, wildcard, valid):
         check(value)
 
 
+def test_type_domain_detect_email():
+    from ..types import domain
+
+    with pytest.raises(ValueError) as exc:
+        domain()('foo@bar.com')
+    assert 'this looks like an email-adress' in str(exc.value)
+
+
 @pytest.mark.parametrize("value,wildcard,expected", [
     ("uberspace.de", False, "uberspace.de"),
     ("uberspace.de.", False, "uberspace.de"),

--- a/paternoster/types/__init__.py
+++ b/paternoster/types/__init__.py
@@ -15,6 +15,12 @@ class domain:
         val = val.encode('idna').decode('ascii')
         domain = val
 
+        if '@' in domain:
+            raise ValueError(
+                "this looks like an email-adress, "
+                "try only supplying the part after the @"
+            )
+
         if val.endswith('.'):
             domain = val = val[:-1]
 


### PR DESCRIPTION
If domain input looks like an email address, mention this in the error message, instead of using the generic `invalid domain`. https://github.com/Uberspace/paternoster/issues/27