### PR TITLE
stop leaking warnings to output

### DIFF
--- a/paternoster/runners/ansiblerunner.py
+++ b/paternoster/runners/ansiblerunner.py
@@ -66,8 +66,9 @@ class MinimalAnsibleCallback(CallbackBase):
     """ filters out all ansible messages except for playbook fails and debug-module-calls. """
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        if not ignore_errors and result._result['msg'] != 'All items completed':
-            print(result._result['msg'], file=sys.stderr)
+        msg = result._result.get('msg')
+        if not ignore_errors and msg is not None and msg != 'All items completed':
+            print(msg, file=sys.stderr)
 
     def v2_runner_item_on_ok(self, result):
         self.v2_runner_on_ok(result)


### PR DESCRIPTION
I suspect that the _v2_runner_on_failed_ method won't always find a `msg` element for `_result` and thus the resulting _KeyError_ is catched in the _send_callback_ method of the parent class… which leads to warning messages in the generated output.

See also https://github.com/Uberspace/paternoster/issues/30