### PR TITLE
Surpress error messagesif `ignored_errors` is set

### DIFF
--- a/paternoster/runners/ansiblerunner.py
+++ b/paternoster/runners/ansiblerunner.py
@@ -67,7 +67,11 @@ class MinimalAnsibleCallback(CallbackBase):
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         msg = result._result.get('msg')
-        if not ignore_errors and msg is not None and msg != 'All items completed':
+        taks_ignores_errors = getattr(result, '_task_fields', {}).get('ignore_errors', False)
+        if (
+            not ignore_errors and not taks_ignores_errors
+            and msg is not None and msg != 'All items completed'
+        ):
             print(msg, file=sys.stderr)
 
     def v2_runner_item_on_ok(self, result):

--- a/paternoster/test/test_ansible_runner.py
+++ b/paternoster/test/test_ansible_runner.py
@@ -122,7 +122,7 @@ def test_output(task, exp_out, exp_err, exp_status, capsys, monkeypatch):
 
 
 @pytest.mark.skipif(SKIP_ANSIBLE_TESTS, reason="ansible <2.4 requires python2")
-def test_msg_handling(capsys, monkeypatch):
+def test_msg_handling_hide_warnings(capsys, monkeypatch):
     """Don't display warning on missing `msg` key in `results`."""
     import os
     from ..runners.ansiblerunner import AnsibleRunner
@@ -136,6 +136,43 @@ def test_msg_handling(capsys, monkeypatch):
           msg: start
       - assert:
           that: 1 == 0
+        ignore_errors: yes
+        with_items:
+        - 1
+        - 2
+      - debug:
+          msg: stop
+    """
+
+    with open(playbook_path, 'w') as f:
+        f.write(playbook)
+
+    monkeypatch.setattr(os, 'chdir', lambda *args, **kwargs: None)
+    AnsibleRunner(playbook_path).run([], False)
+
+    exp_stdout = "start\nstop\n"
+    exp_stderr = ''
+
+    out, err = capsys.readouterr()
+
+    assert out == exp_stdout
+    assert err == exp_stderr
+
+
+@pytest.mark.skipif(SKIP_ANSIBLE_TESTS, reason="ansible <2.4 requires python2")
+def test_msg_handling_hide_nonzero(capsys, monkeypatch):
+    """Don't display `non-zero return code` on failing tasks if errors are ignored."""
+    import os
+    from ..runners.ansiblerunner import AnsibleRunner
+
+    playbook_path = '/tmp/paternoster-test-playbook.yml'
+    playbook = """
+    - hosts: all
+      gather_facts: no
+      tasks:
+      - debug:
+          msg: start
+      - shell: /bin/fail
         ignore_errors: yes
         with_items:
         - 1


### PR DESCRIPTION
If a task hast `ignore_erros: yes`, don't report any errors.

See https://github.com/Uberspace/paternoster/issues/32