### PR TITLE
use safe_load for YAML loading

### DIFF
--- a/paternoster/shebang.py
+++ b/paternoster/shebang.py
@@ -15,7 +15,7 @@ from paternoster.runners.ansiblerunner import AnsibleRunner
 
 def _load_playbook(path):
     with open(path) as f:
-        playbook = yaml.load(f)
+        playbook = yaml.safe_load(f)
 
     assert type(playbook) == list
     return playbook


### PR DESCRIPTION
Use `safe_load` instead of `load` to load YAML.

See https://github.com/Uberspace/paternoster/issues/37