### PR TITLE
s/become_root/become_user/

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ versions you want to test.
 
 ### Integration Tests
 
-Some features (like the `become_root` function) require a correctly setup Linux
+Some features (like the `become_user` function) require a correctly setup Linux
 environment. They can be tested using the provided ansible playbooks in
 `vagrant/tests`.
 


### PR DESCRIPTION
I believe `become_root` is a typo. There's but one mention of that, and it's in a comment in `root.py`